### PR TITLE
update .codeclimate.yml to fix exclusions

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -1,3 +1,25 @@
+engines:
+  duplication:
+    enabled: true
+    config:
+      languages:
+      - ruby
+      - javascript
+      - python
+      - php
+  fixme:
+    enabled: true
+  radon:
+    enabled: true
+ratings:
+  paths:
+  - "**.inc"
+  - "**.js"
+  - "**.jsx"
+  - "**.module"
+  - "**.php"
+  - "**.py"
+  - "**.rb"
 exclude_paths:
-- tests.py
-- migrations/**
+  - "**/tests.py"
+  - "**/migrations/**"


### PR DESCRIPTION
This yml will apply our default configuration for this repo, while excluding your tests and migrations. It looks like the original issue stemmed from incorrect file paths on lines 24 and 25. Merge this in and you should be good to go!